### PR TITLE
Add support for a predicate version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,36 @@ The second argument is the type.
 If the subject doesn't match the provided type, then it raises a formatted exception describing
 what argument *value* was a type mismatch (as an `Isy::ArgumentTypeMismatch` exception).
 
+Alternatively, you can use the predicate version for type assertion:
+
+```ruby
+def fullname segments=[]
+  if isy? segments, Array
+    # passes
+  end
+end
+```
+
+In the previous example, the interface is the same: subject, arguments,
+optional block.  The difference is that if the assertion fails, it will
+catch the `Isy::ArgumentTypeMismatch` exception and return `false`.
+
 ## Usage with an operation
 
 Optionally, in place of a type as the second argument, you can pass a block, and perform
 a more complex comparison operation:
 
 ```ruby
-  def fullname segments
-    isy segments { |seg| seg.length == 3 }
-    # ...
-  end
+def fullname segments
+  isy segments { |seg| seg.length == 3 }
+  # ...
+end
 ```
 
 As illustrated above, `isy` yields to the operation the first argument (segments).  The expectation
 is that the value returned by the operation (block) is a boolen (true => passes, false => failed).
+
+*Note: predicate version has the same support*
 
 ## Performance
 

--- a/lib/isy/methods.rb
+++ b/lib/isy/methods.rb
@@ -40,14 +40,49 @@ module Isy
           'Object#isy requires either a type or evaluation block'
       end
 
-      evaluation ||= lambda { |s| s.is_a? args[0] }
+      evaluation ||= ->(s) { s.is_a? args[0] }
+      is_valid = !!(evaluation.call subject)
 
-      unless evaluation.call(subject)
+      unless is_valid
         raise Isy::ArgumentTypeMismatch.new(
           subject: subject,
           caller_method: caller_locations(1,1)[0].label
         )
       end
+
+      is_valid
+    end
+
+    # Isy::Methods#isy?
+    #
+    # == Usage
+    #
+    # The implementation follows the same workflow as `isy` with one exception (pun intended): returns a boolen.
+    #
+    #   def fullname segments
+    #     if isy? segments, Array
+    #       # passes
+    #     end
+    #   end
+    #
+    # If the subject doesn't match the provided type, then it returns false
+    #
+    # == Usage with an operation
+    #
+    # Optionally, in place of a type as the second argument, you can pass a block, and perform
+    # a more complex comparison operation:
+    #
+    #   def fullname segments
+    #     isy? segments { |seg| seg.length == 3 }
+    #   end
+    #
+    # As illustrated above, `isy?` yields to the operation the first argument (segments).  The expectation
+    # is that the value returned by the operation (block) is a boolen (true => passes, false => failed).
+    #
+    def isy? subject, *args, &evaluation
+      isy subject, *args, &evaluation
+    rescue ArgumentTypeMismatch
+      false
     end
   end
 end

--- a/spec/isy_spec.rb
+++ b/spec/isy_spec.rb
@@ -40,5 +40,23 @@ describe Isy do
       end
     end
   end
+
+  describe '#isy?' do
+    subject { isy? test_value, type }
+
+    context 'when the subject passes' do
+      let(:test_value) { 'test value' }
+      let(:type) { String }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when the subject fails' do
+      let(:test_value) { 'test value' }
+      let(:type) { Hash }
+
+      it { is_expected.to eq false }
+    end
+  end
 end
 


### PR DESCRIPTION
Same interface as the `isn` version,  In fact, it all but delegates to that method and catches the `Isy::ArgumentTypeMismatch` exception and returns false.
